### PR TITLE
Control initial state for empty image url.

### DIFF
--- a/lib/components/avatar.dart
+++ b/lib/components/avatar.dart
@@ -23,7 +23,7 @@ class _AvatarState extends State<Avatar> {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        if (widget.imageUrl == null)
+        if (widget.imageUrl == null || widget.imageUrl!.isEmpty)
           Container(
             width: 150,
             height: 150,


### PR DESCRIPTION
On second widget rebuild the imageUrl is not null but an empty string.